### PR TITLE
Fix IllegalAccessError w/Scala Interoperability.

### DIFF
--- a/src/main/java/org/isomorphism/util/TokenBuckets.java
+++ b/src/main/java/org/isomorphism/util/TokenBuckets.java
@@ -83,7 +83,7 @@ public final class TokenBuckets
     }
 
     /** Build the token bucket. */
-    public TokenBucketImpl build()
+    public TokenBucket build()
     {
       checkNotNull(capacity, "Must specify a capacity");
       checkNotNull(refillStrategy, "Must specify a refill strategy");


### PR DESCRIPTION
I upgraded to 1.3 and discovered that the token buckets were not working due to:
```
java.lang.IllegalAccessError: tried to access class org.isomorphism.util.TokenBucketImpl
```

`TokenBucketImpl` is package private and should not escape package scope via `TokenBuckets.builder().build()`. 

The broken usage looks like:
```scala
val tokenBucket = TokenBuckets.builder()
  .withCapacity(5)
  .withFixedIntervalRefillStrategy(1, 200, TimeUnit.MILLISECONDS)
  .build()

tokenBucket.consume()
```

It's trying to invoke the package private `TokenBucketImpl.consume()` instead of the public API `TokenBucket.consume()`. A simple workaround is to explicitly set the type of `tokenBucket`, though I think this fix is a bit more honest w.r.t. the token-bucket API.

Regardless, I don't know how this is not a java compiler error; scala is a lot more picky about leaking private types. Perhaps it is because you could never create a variable of type `TokenBucketImpl` in java if you weren't in the proper package.