### PR TITLE
Add methods to allow introspection into the state of the bucket.

### DIFF
--- a/src/main/java/org/isomorphism/util/FixedIntervalRefillStrategy.java
+++ b/src/main/java/org/isomorphism/util/FixedIntervalRefillStrategy.java
@@ -47,6 +47,7 @@ public class FixedIntervalRefillStrategy implements TokenBucketImpl.RefillStrate
     this.nextRefillTime = -1;
   }
 
+  @Override
   public synchronized long refill()
   {
     long now = ticker.read();
@@ -55,6 +56,12 @@ public class FixedIntervalRefillStrategy implements TokenBucketImpl.RefillStrate
     }
     nextRefillTime = now + periodInNanos;
     return numTokens;
+  }
+
+  @Override
+  public long getDurationUntilNextRefill(TimeUnit unit) {
+    long now = ticker.read();
+    return unit.convert(Math.max(0, nextRefillTime - now), TimeUnit.NANOSECONDS);
   }
 }
 

--- a/src/main/java/org/isomorphism/util/TokenBucket.java
+++ b/src/main/java/org/isomorphism/util/TokenBucket.java
@@ -24,6 +24,21 @@ package org.isomorphism.util;
 public interface TokenBucket
 {
   /**
+   * Returns the capacity of this token bucket.  This is the maximum number of tokens that the bucket can hold at
+   * any one time.
+   *
+   * @return The capacity of the bucket.
+   */
+  long getCapacity();
+
+  /**
+   * Returns the current number of tokens in the bucket.  If the bucket is empty then this method will return 0.
+   *
+   * @return The current number of tokens in the bucket.
+   */
+  long getNumTokens();
+
+  /**
    * Attempt to consume a single token from the bucket.  If it was consumed then {@code true} is returned, otherwise
    * {@code false} is returned.
    *

--- a/src/main/java/org/isomorphism/util/TokenBucket.java
+++ b/src/main/java/org/isomorphism/util/TokenBucket.java
@@ -15,6 +15,8 @@
  */
 package org.isomorphism.util;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A token bucket is used for rate limiting access to a portion of code.
  *
@@ -37,6 +39,16 @@ public interface TokenBucket
    * @return The current number of tokens in the bucket.
    */
   long getNumTokens();
+
+  /**
+   * Returns the amount of time in the specified time unit until the next group of tokens can be added to the token
+   * bucket.
+   *
+   * @see org.isomorphism.util.TokenBucket.RefillStrategy#getDurationUntilNextRefill(java.util.concurrent.TimeUnit)
+   * @param unit The time unit to express the return value in.
+   * @return The amount of time until the next group of tokens can be added to the token bucket.
+   */
+  long getDurationUntilNextRefill(TimeUnit unit) throws UnsupportedOperationException;
 
   /**
    * Attempt to consume a single token from the bucket.  If it was consumed then {@code true} is returned, otherwise
@@ -78,6 +90,20 @@ public interface TokenBucket
      * @return The number of tokens to add to the token bucket.
      */
     long refill();
+
+    /**
+     * Returns the amount of time in the specified time unit until the next group of tokens can be added to the token
+     * bucket.  Please note, depending on the {@code SleepStrategy} used by the token bucket, tokens may not actually
+     * be added until much after the returned duration.  If for some reason the implementation of
+     * {@code RefillStrategy} doesn't support knowing when the next batch of tokens will be added, then an
+     * {@code UnsupportedOperationException} may be thrown.  Lastly, if the duration until the next time tokens will
+     * be added to the token bucket is less than a single unit of the passed in time unit then this method will
+     * return 0.
+     *
+     * @param unit The time unit to express the return value in.
+     * @return The amount of time until the next group of tokens can be added to the token bucket.
+     */
+    long getDurationUntilNextRefill(TimeUnit unit) throws UnsupportedOperationException;
   }
 
   /** Encapsulation of a strategy for relinquishing control of the CPU. */

--- a/src/main/java/org/isomorphism/util/TokenBucketImpl.java
+++ b/src/main/java/org/isomorphism/util/TokenBucketImpl.java
@@ -15,6 +15,8 @@
  */
 package org.isomorphism.util;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -72,6 +74,19 @@ class TokenBucketImpl implements TokenBucket
     refill();
 
     return size;
+  }
+
+  /**
+  * Returns the amount of time in the specified time unit until the next group of tokens can be added to the token
+  * bucket.
+  *
+  * @see org.isomorphism.util.TokenBucket.RefillStrategy#getDurationUntilNextRefill(java.util.concurrent.TimeUnit)
+  * @param unit The time unit to express the return value in.
+  * @return The amount of time until the next group of tokens can be added to the token bucket.
+  */
+  @Override
+  public long getDurationUntilNextRefill(TimeUnit unit) throws UnsupportedOperationException {
+    return refillStrategy.getDurationUntilNextRefill(unit);
   }
 
   /**

--- a/src/test/java/org/isomorphism/util/FixedIntervalRefillStrategyTest.java
+++ b/src/test/java/org/isomorphism/util/FixedIntervalRefillStrategyTest.java
@@ -58,6 +58,37 @@ public class FixedIntervalRefillStrategyTest
     }
   }
 
+  @Test
+  public void testDurationUntilFirstRefill() {
+    // A refill has never happened, so one is supposed to happen immediately.
+    assertEquals(0, strategy.getDurationUntilNextRefill(TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testDurationAfterFirstRefill() {
+    strategy.refill();
+
+    for (int i = 0; i < P - 1; i++) {
+      assertEquals(P - i, strategy.getDurationUntilNextRefill(TimeUnit.SECONDS));
+      ticker.advance(1, U);
+    }
+  }
+
+  @Test
+  public void testDurationAtSecondRefillTime() {
+    strategy.refill();
+    ticker.advance(P, U);
+
+    assertEquals(0, strategy.getDurationUntilNextRefill(TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testDurationInProperUnits() {
+    strategy.refill();
+
+    assertEquals(10000, strategy.getDurationUntilNextRefill(TimeUnit.MILLISECONDS));
+  }
+
   private static final class MockTicker extends Ticker
   {
     private long now = 0;

--- a/src/test/java/org/isomorphism/util/TokenBucketImplTest.java
+++ b/src/test/java/org/isomorphism/util/TokenBucketImplTest.java
@@ -17,6 +17,8 @@ package org.isomorphism.util;
 
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -158,6 +160,11 @@ public class TokenBucketImplTest
       long numTokens = numTokensToAdd;
       numTokensToAdd = 0;
       return numTokens;
+    }
+
+    @Override
+    public long getDurationUntilNextRefill(TimeUnit unit) throws UnsupportedOperationException {
+      throw new UnsupportedOperationException();
     }
 
     public void addToken()

--- a/src/test/java/org/isomorphism/util/TokenBucketImplTest.java
+++ b/src/test/java/org/isomorphism/util/TokenBucketImplTest.java
@@ -17,6 +17,7 @@ package org.isomorphism.util;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -28,6 +29,68 @@ public class TokenBucketImplTest
   private final MockRefillStrategy refillStrategy = new MockRefillStrategy();
   private final TokenBucket.SleepStrategy sleepStrategy = mock(TokenBucket.SleepStrategy.class);
   private final TokenBucketImpl bucket = new TokenBucketImpl(CAPACITY, refillStrategy, sleepStrategy);
+
+  @Test
+  public void testGetCapacity() {
+    assertEquals(CAPACITY, bucket.getCapacity());
+  }
+
+  @Test
+  public void testEmptyBucketHasZeroTokens() {
+    assertEquals(0, bucket.getNumTokens());
+  }
+
+  @Test
+  public void testAddingTokenIncreasesNumTokens() {
+    refillStrategy.addToken();
+    assertEquals(1, bucket.getNumTokens());
+  }
+
+  @Test
+  public void testAddingMultipleTokensIncreasesNumTokens() {
+    refillStrategy.addTokens(2);
+    assertEquals(2, bucket.getNumTokens());
+  }
+
+  @Test
+  public void testAtCapacityNumTokens() {
+    refillStrategy.addTokens(CAPACITY);
+    assertEquals(CAPACITY, bucket.getNumTokens());
+  }
+
+  @Test
+  public void testOverCapacityNumTokens() {
+    refillStrategy.addTokens(CAPACITY + 1);
+    assertEquals(CAPACITY, bucket.getNumTokens());
+  }
+
+  @Test
+  public void testConsumingTokenDecreasesNumTokens() {
+    refillStrategy.addTokens(1);
+    bucket.consume();
+    assertEquals(0, bucket.getNumTokens());
+  }
+
+  @Test
+  public void testConsumingMultipleTokensDecreasesNumTokens() {
+    refillStrategy.addTokens(CAPACITY);
+    bucket.consume(2);
+    assertEquals(CAPACITY - 2, bucket.getNumTokens());
+  }
+
+  @Test
+  public void testEmptyNumTokens() {
+    refillStrategy.addTokens(CAPACITY);
+    bucket.consume(CAPACITY);
+    assertEquals(0, bucket.getNumTokens());
+  }
+
+  @Test
+  public void testFailedConsumeKeepsNumTokens() {
+    refillStrategy.addTokens(1);
+    bucket.tryConsume(2);
+    assertEquals(1, bucket.getNumTokens());
+  }
 
   @Test(expected = IllegalArgumentException.class)
   public void testTryConsumeZeroTokens()


### PR DESCRIPTION
This pull request introduces the ability to look into the state of the token bucket and determine

1. What the bucket's capacity is.
2. How many tokens are currently in the bucket.
3. How long until more tokens *may* be added to the bucket.

@mmadson I believe this pull request will address the features you requested in #4.  Please have a look and give me feedback.  The only change I made from your suggestion was that the implementation of `TokenBucket.getDurationUntilNextRefill` returns a duration until the next refill vs the UTC timestamp of the next refill.  The reason for this is because the existing refill strategy uses `System.nanoTime` as its mechanism of keeping time.  `System.nanoTime` while very high precision is however not directly translatable to the system or wall-clock -- it's only suitable for performing relative computations.  Given that it seemed more straightforward and more generally useful to return a duration vs an absolute timestamp.  For your particular use case you'll need to offset the current time by that duration.
