### PR TITLE
Make member variables volatile

### DIFF
--- a/src/main/java/org/isomorphism/util/TokenBucket.java
+++ b/src/main/java/org/isomorphism/util/TokenBucket.java
@@ -93,7 +93,7 @@ public interface TokenBucket
   static interface RefillStrategy
   {
     /**
-     * Returns the number of tokens to add to the token bucket.
+     * Returns the number of tokens to add to the token bucket based on when the bucket was last refilled.
      *
      * @return The number of tokens to add to the token bucket.
      */

--- a/src/main/java/org/isomorphism/util/TokenBucketImpl.java
+++ b/src/main/java/org/isomorphism/util/TokenBucketImpl.java
@@ -39,7 +39,7 @@ class TokenBucketImpl implements TokenBucket
   private final long capacity;
   private final RefillStrategy refillStrategy;
   private final SleepStrategy sleepStrategy;
-  private long size;
+  private volatile long size;
 
   TokenBucketImpl(long capacity, long initialTokens, RefillStrategy refillStrategy, SleepStrategy sleepStrategy)
   {


### PR DESCRIPTION
Make non-final members of FixedIntervalRefillStrategy and
TokenBucketImpl volatile, to ensure that changes to their values
will be immediately visible in other threads. Since all updates to
those member variables occur in synchronized methods, this change
is sufficient to prevent race conditions.

Tweak javadoc for TokenBucket.RefillStrategy.refill() to make it
clearer that the method should not return a fixed value.
