### PR TITLE
Use the newer java.time.Duration to represent duration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+  - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
   </licenses>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -63,6 +65,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>18.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.threeten</groupId>
+      <artifactId>threeten-extra</artifactId>
+      <version>1.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/isomorphism/util/TokenBucket.java
+++ b/src/main/java/org/isomorphism/util/TokenBucket.java
@@ -15,6 +15,7 @@
  */
 package org.isomorphism.util;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -47,8 +48,19 @@ public interface TokenBucket
    * @see org.isomorphism.util.TokenBucket.RefillStrategy#getDurationUntilNextRefill(java.util.concurrent.TimeUnit)
    * @param unit The time unit to express the return value in.
    * @return The amount of time until the next group of tokens can be added to the token bucket.
+   *
+   * @deprecated since 1.8, see {@link TokenBucket#getDurationUntilNextRefill()}
    */
+  @Deprecated
   long getDurationUntilNextRefill(TimeUnit unit) throws UnsupportedOperationException;
+
+  /**
+   * Returns the amount of time until the next group of tokens can be added to the token bucket.
+   *
+   * @see org.isomorphism.util.TokenBucket.RefillStrategy#getDurationUntilNextRefill()
+   * @return The amount of time until the next group of tokens can be added to the token bucket.
+   */
+  Duration getDurationUntilNextRefill() throws UnsupportedOperationException;
 
   /**
    * Attempt to consume a single token from the bucket.  If it was consumed then {@code true} is returned, otherwise
@@ -110,8 +122,24 @@ public interface TokenBucket
      *
      * @param unit The time unit to express the return value in.
      * @return The amount of time until the next group of tokens can be added to the token bucket.
+     *
+     * @deprecated since 1.8, see {@link RefillStrategy#getDurationUntilNextRefill()}
      */
+    @Deprecated
     long getDurationUntilNextRefill(TimeUnit unit) throws UnsupportedOperationException;
+
+    /**
+     * Returns the amount of time until the next group of tokens can be added to the token
+     * bucket.  Please note, depending on the {@code SleepStrategy} used by the token bucket, tokens may not actually
+     * be added until much after the returned duration.  If for some reason the implementation of
+     * {@code RefillStrategy} doesn't support knowing when the next batch of tokens will be added, then an
+     * {@code UnsupportedOperationException} may be thrown.  Lastly, if the duration until the next time tokens will
+     * be added to the token bucket is less than a single unit of the passed in time unit then this method will
+     * return 0.
+     *
+     * @return The amount of time until the next group of tokens can be added to the token bucket.
+     */
+    Duration getDurationUntilNextRefill();
   }
 
   /** Encapsulation of a strategy for relinquishing control of the CPU. */

--- a/src/main/java/org/isomorphism/util/TokenBucketImpl.java
+++ b/src/main/java/org/isomorphism/util/TokenBucketImpl.java
@@ -15,10 +15,12 @@
  */
 package org.isomorphism.util;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * A token bucket implementation that is of a leaky bucket in the sense that it has a finite capacity and any added
@@ -80,17 +82,31 @@ class TokenBucketImpl implements TokenBucket
   }
 
   /**
-  * Returns the amount of time in the specified time unit until the next group of tokens can be added to the token
-  * bucket.
-  *
-  * @see org.isomorphism.util.TokenBucket.RefillStrategy#getDurationUntilNextRefill(java.util.concurrent.TimeUnit)
-  * @param unit The time unit to express the return value in.
-  * @return The amount of time until the next group of tokens can be added to the token bucket.
-  */
+   * Returns the amount of time in the specified time unit until the next group of tokens can be added to the token
+   * bucket.
+   *
+   * @see org.isomorphism.util.TokenBucket.RefillStrategy#getDurationUntilNextRefill(java.util.concurrent.TimeUnit)
+   * @param unit The time unit to express the return value in.
+   * @return The amount of time until the next group of tokens can be added to the token bucket.
+   */
   @Override
+  @Deprecated
   public long getDurationUntilNextRefill(TimeUnit unit) throws UnsupportedOperationException
   {
-    return refillStrategy.getDurationUntilNextRefill(unit);
+    return unit.convert(getDurationUntilNextRefill().toNanos(), NANOSECONDS);
+  }
+
+  /**
+   * Returns the amount of time in the specified time unit until the next group of tokens can be added to the token
+   * bucket.
+   *
+   * @see org.isomorphism.util.TokenBucket.RefillStrategy#getDurationUntilNextRefill()
+   * @return The amount of time until the next group of tokens can be added to the token bucket.
+   */
+  @Override
+  public Duration getDurationUntilNextRefill() throws UnsupportedOperationException
+  {
+    return refillStrategy.getDurationUntilNextRefill();
   }
 
   /**

--- a/src/main/java/org/isomorphism/util/TokenBuckets.java
+++ b/src/main/java/org/isomorphism/util/TokenBuckets.java
@@ -17,11 +17,14 @@ package org.isomorphism.util;
 
 import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.threeten.extra.Temporals;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.threeten.extra.Temporals.chronoUnit;
 
 /** Static utility methods pertaining to creating {@link TokenBucketImpl} instances. */
 public final class TokenBuckets
@@ -58,10 +61,21 @@ public final class TokenBuckets
       return this;
     }
 
-    /** Refill tokens at a fixed interval. */
+    /**
+     * Refill tokens at a fixed interval.
+     *
+     * @deprecated since 1.8, see {@link TokenBuckets.Builder#withFixedIntervalRefillStrategy(long, Duration)}
+     */
+    @Deprecated
     public Builder withFixedIntervalRefillStrategy(long refillTokens, long period, TimeUnit unit)
     {
-      return withRefillStrategy(new FixedIntervalRefillStrategy(ticker, refillTokens, period, unit));
+      return withFixedIntervalRefillStrategy(refillTokens, Duration.of(period, chronoUnit(unit)));
+    }
+
+    /** Refill tokens at a fixed interval. */
+    public Builder withFixedIntervalRefillStrategy(long refillTokens, Duration period)
+    {
+      return withRefillStrategy(new FixedIntervalRefillStrategy(ticker, refillTokens, period));
     }
 
     /** Use a user defined refill strategy. */

--- a/src/test/java/org/isomorphism/util/TokenBucketImplTest.java
+++ b/src/test/java/org/isomorphism/util/TokenBucketImplTest.java
@@ -17,6 +17,7 @@ package org.isomorphism.util;
 
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -231,6 +232,11 @@ public class TokenBucketImplTest
     @Override
     public long getDurationUntilNextRefill(TimeUnit unit) throws UnsupportedOperationException
     {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Duration getDurationUntilNextRefill() {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Up to now the code used (or abused) java.util.concurrent.TimeUnit. Duration
is a better representation, which encapsulate the amount and the unit in a
single class.

Method using TimeUnit have been deprecated and delegate to the new methods
using Duration. A dependency to threeten-extra has been added to do this
conversion. It can be removed once all TimeUnit based methods have been
removed.

Pushed minimum compiler version to 1.8 to allow the use of Duration.